### PR TITLE
Add Next.js project for Korean products store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# ai_code
+# Korean Products Store
+
+Este proyecto es un ejemplo de tienda y promoción de productos coreanos creada con **Next.js**. Está pensada para ser desplegada en [Vercel](https://vercel.com/).
+
+## Comandos
+
+```bash
+npm run dev     # Desarrollo
+npm run build   # Compilar para producción
+npm start       # Ejecutar versión compilada
+```
+
+## Deploy en Vercel
+
+1. Crea una cuenta en [Vercel](https://vercel.com/) si no la tienes.
+2. Importa este repositorio desde Vercel.
+3. Usa la configuración por defecto de proyecto **Next.js**.
+4. Despliega y disfruta de tu nueva tienda de productos coreanos.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "korean-products",
+  "version": "1.0.0",
+  "description": "Site for selling and promoting Korean products",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "license": "MIT"
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Korean Products Store</title>
+        <meta name="description" content="Best Korean products" />
+      </Head>
+      <main>
+        <h1>Bienvenido a la Tienda Coreana</h1>
+        <p>Explora nuestra selección de productos coreanos.</p>
+      </main>
+    </div>
+  )
+}

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,0 +1,20 @@
+export default function Products() {
+  const items = [
+    { id: 1, name: 'Kimchi', price: '$5.99' },
+    { id: 2, name: 'Korean BBQ Sauce', price: '$7.99' },
+    { id: 3, name: 'Gochujang', price: '$4.50' },
+  ];
+
+  return (
+    <div>
+      <h1>Productos</h1>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.name} - {item.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/public/README.txt
+++ b/public/README.txt
@@ -1,0 +1,1 @@
+Static assets for the Korean products site.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,8 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+h1 {
+  color: #CC0000;
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project structure
- add example pages and global styling
- provide instructions for running and Vercel deployment

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840c52a24bc8328abdd779ef3dc7c96