### PR TITLE
Enhance home page with hero and product grid

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,14 @@
+import styles from '../styles/Hero.module.css'
+import Link from 'next/link'
+
+export default function Hero() {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.content}>
+        <h1>Descubre la belleza de la cosmética coreana</h1>
+        <p>Productos originales, envío rápido y consejos de skincare.</p>
+        <Link href="/products" className={styles.cta}>Ver novedades</Link>
+      </div>
+    </section>
+  )
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -5,8 +5,9 @@ export default function NavBar() {
   return (
     <nav className={styles.nav}>
       <ul>
-        <li><Link href="/">Home</Link></li>
+        <li><Link href="/">Inicio</Link></li>
         <li><Link href="/products">Productos</Link></li>
+        <li><Link href="#contacto">Contacto</Link></li>
       </ul>
     </nav>
   )

--- a/components/ProductGrid.js
+++ b/components/ProductGrid.js
@@ -1,0 +1,36 @@
+import styles from '../styles/ProductGrid.module.css'
+
+const products = [
+  {
+    id: 1,
+    name: 'Sérum de niacinamida',
+    price: '$18.00',
+    image: 'https://via.placeholder.com/200x200.png?text=Serum',
+  },
+  {
+    id: 2,
+    name: 'Protector solar SPF50',
+    price: '$22.00',
+    image: 'https://via.placeholder.com/200x200.png?text=Sunblock',
+  },
+  {
+    id: 3,
+    name: 'Crema hidratante',
+    price: '$15.50',
+    image: 'https://via.placeholder.com/200x200.png?text=Crema',
+  },
+]
+
+export default function ProductGrid() {
+  return (
+    <section className={styles.grid}>
+      {products.map(product => (
+        <div key={product.id} className={styles.card}>
+          <img src={product.image} alt={product.name} />
+          <h3>{product.name}</h3>
+          <p className={styles.price}>{product.price}</p>
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,7 @@
 import Head from 'next/head'
 import ProductCarousel from '../components/ProductCarousel'
+import Hero from '../components/Hero'
+import ProductGrid from '../components/ProductGrid'
 
 export default function Home() {
   return (
@@ -9,9 +11,14 @@ export default function Home() {
         <meta name="description" content="Best Korean products" />
       </Head>
       <main>
-        <h1>Bienvenido a la Tienda Coreana</h1>
-        <p>Explora nuestra selección de productos coreanos.</p>
+        <Hero />
+        <h2>Productos en tendencia</h2>
+        <ProductGrid />
         <ProductCarousel />
+        <section id="contacto">
+          <h2>Contáctanos</h2>
+          <p>Escríbenos a contacto@example.com</p>
+        </section>
       </main>
     </div>
   )

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,20 +1,10 @@
-export default function Products() {
-  const items = [
-    { id: 1, name: 'Kimchi', price: '$5.99' },
-    { id: 2, name: 'Korean BBQ Sauce', price: '$7.99' },
-    { id: 3, name: 'Gochujang', price: '$4.50' },
-  ];
+import ProductGrid from '../components/ProductGrid'
 
+export default function Products() {
   return (
     <div>
-      <h1>Productos</h1>
-      <ul>
-        {items.map((item) => (
-          <li key={item.id}>
-            {item.name} - {item.price}
-          </li>
-        ))}
-      </ul>
+      <h1>Todos los productos</h1>
+      <ProductGrid />
     </div>
-  );
+  )
 }

--- a/styles/Hero.module.css
+++ b/styles/Hero.module.css
@@ -1,0 +1,32 @@
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #ffe4e6, #fdf2f8);
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+.content h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #5c3a5c;
+}
+
+.content p {
+  margin: 1rem 0;
+  color: #555;
+}
+
+.cta {
+  background-color: #ec4899;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.cta:hover {
+  background-color: #db2777;
+}

--- a/styles/NavBar.module.css
+++ b/styles/NavBar.module.css
@@ -1,6 +1,10 @@
 .nav {
-  background-color: #333;
+  background-color: #fdf2f8;
   padding: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 .nav ul {
@@ -12,6 +16,6 @@
 }
 
 .nav a {
-  color: white;
+  color: #5c3a5c;
   text-decoration: none;
 }

--- a/styles/ProductGrid.module.css
+++ b/styles/ProductGrid.module.css
@@ -1,0 +1,31 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem 0;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 1rem;
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.card img {
+  width: 100%;
+  height: auto;
+  margin-bottom: 0.5rem;
+}
+
+.price {
+  color: #ec4899;
+  font-weight: bold;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,8 +1,18 @@
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Arial', sans-serif;
+  background-color: #faf5ff;
+  color: #333;
 }
 
-h1 {
-  color: #CC0000;
+h1,
+h2,
+h3 {
+  color: #5c3a5c;
+}
+
+#contacto {
+  background-color: #fff1f2;
+  padding: 2rem 1rem;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- add Hero section with CTA
- display trending products in a grid
- update navigation links and make navbar sticky
- restyle global colors and fonts
- update products page to use grid

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c98e1a9883289bbd634c4a488b0d