### PR TITLE
Use Unsplash images for product cards

### DIFF
--- a/components/ProductGrid.js
+++ b/components/ProductGrid.js
@@ -5,19 +5,19 @@ const products = [
     id: 1,
     name: 'Sérum de niacinamida',
     price: '$18.00',
-    image: 'https://via.placeholder.com/200x200.png?text=Serum',
+    image: 'https://source.unsplash.com/200x200/?serum',
   },
   {
     id: 2,
     name: 'Protector solar SPF50',
     price: '$22.00',
-    image: 'https://via.placeholder.com/200x200.png?text=Sunblock',
+    image: 'https://source.unsplash.com/200x200/?sunscreen',
   },
   {
     id: 3,
     name: 'Crema hidratante',
     price: '$15.50',
-    image: 'https://via.placeholder.com/200x200.png?text=Crema',
+    image: 'https://source.unsplash.com/200x200/?moisturizer',
   },
 ]
 


### PR DESCRIPTION
## Summary
- swap placeholder images in `ProductGrid` for Unsplash image URLs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479acff58c832886b5708bb8c323f7