### PR TITLE
Add ESLint, Prettier and Jest setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/__tests__/NavBar.test.js
+++ b/__tests__/NavBar.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import NavBar from '../components/NavBar'
+import '@testing-library/jest-dom'
+
+describe('NavBar', () => {
+  it('renders navigation links', () => {
+    render(<NavBar />)
+    expect(screen.getByText('Inicio')).toBeInTheDocument()
+    expect(screen.getByText('Productos')).toBeInTheDocument()
+    expect(screen.getByText('Contacto')).toBeInTheDocument()
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,14 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/package.json
+++ b/package.json
@@ -6,12 +6,18 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- configure ESLint with Next.js rules
- add Prettier config
- set up Jest with Testing Library
- include sample NavBar test

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce2df71088328b1f3af673b1cd6b3