### PR TITLE
Add dynamic product pages

### DIFF
--- a/components/ProductGrid.js
+++ b/components/ProductGrid.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import styles from '../styles/ProductGrid.module.css'
+import Link from "next/link"
 
 export default function ProductGrid() {
   const [products, setProducts] = useState([])
@@ -14,13 +15,13 @@ export default function ProductGrid() {
   return (
     <section className={styles.grid}>
       {products.map(product => (
-        <div key={product.id} className={styles.card}>
+        <Link key={product.id} href={`/products/${product.id}`} className={styles.card}>
           <Image src={product.image} alt={product.title || product.name} width={200} height={200} />
           <h3>{product.title || product.name}</h3>
           <p className={styles.price}>
             {typeof product.price === 'number' ? `$${product.price}` : product.price}
           </p>
-        </div>
+        </Link>
       ))}
     </section>
   )

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -1,0 +1,27 @@
+import Image from 'next/image'
+
+export async function getStaticPaths() {
+  const res = await fetch('https://fakestoreapi.com/products?limit=3')
+  const products = await res.json()
+  const paths = products.map(product => ({
+    params: { id: product.id.toString() }
+  }))
+  return { paths, fallback: false }
+}
+
+export async function getStaticProps({ params }) {
+  const res = await fetch(`https://fakestoreapi.com/products/${params.id}`)
+  const product = await res.json()
+  return { props: { product } }
+}
+
+export default function ProductDetail({ product }) {
+  return (
+    <div>
+      <h1>{product.title || product.name}</h1>
+      <Image src={product.image} alt={product.title || product.name} width={300} height={300} />
+      <p>{typeof product.price === 'number' ? `$${product.price}` : product.price}</p>
+      {product.description && <p>{product.description}</p>}
+    </div>
+  )
+}

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -1,4 +1,4 @@
-import ProductGrid from '../components/ProductGrid'
+import ProductGrid from '../../components/ProductGrid'
 
 export default function Products() {
   return (


### PR DESCRIPTION
## Summary
- add dynamic product detail page using Next.js routing
- relocate products index page into its own folder
- link each product card to its detail page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce5ce051083288196944f9b681095